### PR TITLE
fix(tsconfig): Change TS compiler target to `ES5` for cross-browser compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es5",
+    "lib": ["ESNext"],
     "module": "commonjs",
     "declaration": true,
     "outDir": "./lib",


### PR DESCRIPTION
### Description
- Changes TS compiler target to `ES5` from `ESNext` to prevent incompatibility issues on old browsers
- Adds `ESNext` library to `tsconfig` to be able to use new features, while targeting `ES5`

### Related Issues
- Resolves #13