### PR TITLE
fix: Make sure message format options apply to nested error details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ npm-debug.log
 
 # We gitignore the `/lib` but whitelist it at files property at package.json
 /lib
+
+.history

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hipo/hipo-exceptions-js",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hipo/hipo-exceptions-js",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "JavaScript client for parsing the hipo-drf-exceptions",
   "main": "lib/index.js",
   "files": [

--- a/src/ExceptionTransformer.ts
+++ b/src/ExceptionTransformer.ts
@@ -151,9 +151,11 @@ class ExceptionTransformer {
           finalMessage = getStringMessage(
             removeKnownKeysFromErrorDetail(errorDetail, knownErrorKeys),
             {
-              shouldHideErrorKey,
-              shouldCapitalizeErrorKey,
-              fieldLabelMap
+              keyOptions: {
+                shouldHideErrorKey,
+                shouldCapitalizeErrorKey,
+                fieldLabelMap
+              }
             }
           );
         } else {

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -50,7 +50,6 @@ function generateFieldErrorFromErrorDetail(
 }
 
 interface StringMessageGeneratorKeyOptions {
-  customKey?: string;
   shouldCapitalizeErrorKey?: boolean;
   shouldHideErrorKey?: boolean;
   fieldLabelMap?: {[key: string]: string};
@@ -58,16 +57,17 @@ interface StringMessageGeneratorKeyOptions {
 
 function getStringMessage(
   errorDetailValue: ExceptionDetailValue,
-  keyOptions?: StringMessageGeneratorKeyOptions
+  options?: {key?: string; keyOptions?: StringMessageGeneratorKeyOptions}
 ): string {
   let message = "";
 
   if (Array.isArray(errorDetailValue)) {
     if (isArrayOfStrings(errorDetailValue)) {
+      // This is the exit condition of this recursion, string message can be generated now
       // errorDetailValue = ["", ""]
       message = generateMessageFromStringArray(
         errorDetailValue,
-        keyOptions?.customKey
+        generateErrorKeyToDisplay(options?.key || "", options?.keyOptions)
       );
     } else if (isArrayOfObjects(errorDetailValue)) {
       // errorDetailValue = [ {}, {}, {..} ]
@@ -76,7 +76,9 @@ function getStringMessage(
       );
 
       if (firstNonEmptyErrorObject) {
-        message = getStringMessage(firstNonEmptyErrorObject, keyOptions);
+        message = getStringMessage(firstNonEmptyErrorObject, {
+          keyOptions: options?.keyOptions
+        });
       }
     }
   } else if (typeof errorDetailValue === "object") {
@@ -89,29 +91,19 @@ function getStringMessage(
         errorDetailKeys.includes("non_field_errors") &&
         errorDetailValue.non_field_errors
       ) {
-        message = getStringMessage(
-          errorDetailValue.non_field_errors,
-          keyOptions
-        );
+        message = getStringMessage(errorDetailValue.non_field_errors, {
+          keyOptions: options?.keyOptions
+        });
       } else {
         const defaultErrorKey = errorDetailKeys[0];
 
-        // If error detail is array of objects, it is a nested error, so
-        // generation should continue with the original key options
-        if (isArrayOfObjects(errorDetailValue[defaultErrorKey])) {
-          message = getStringMessage(
-            errorDetailValue[defaultErrorKey],
-            keyOptions
-          );
-        } else {
-          message = getStringMessage(errorDetailValue[defaultErrorKey], {
-            // If not an array of objects, generate final error key using options
-            customKey: getErrorKeyForStringMessageGenerator(
-              defaultErrorKey,
-              keyOptions
-            )
-          });
-        }
+        // Start recursion again with the first key's value
+        // `key` should be sent in case `errorDetailValue[defaultErrorKey]` is the recursion's exit value: string[]
+        // `key` then can be processed according to `keyOptions`
+        message = getStringMessage(errorDetailValue[defaultErrorKey], {
+          key: defaultErrorKey,
+          keyOptions: options?.keyOptions
+        });
       }
     }
   } else {
@@ -122,16 +114,14 @@ function getStringMessage(
   return message;
 }
 
-function getErrorKeyForStringMessageGenerator(
+function generateErrorKeyToDisplay(
   defaultErrorKey: string,
   keyOptions: StringMessageGeneratorKeyOptions | undefined
-) {
+): string | undefined {
   let errorKey: string | undefined = defaultErrorKey;
 
   if (keyOptions?.shouldHideErrorKey) {
     errorKey = undefined;
-  } else if (keyOptions?.customKey) {
-    errorKey = keyOptions?.customKey;
   } else if (keyOptions?.fieldLabelMap?.[defaultErrorKey]) {
     errorKey = keyOptions.fieldLabelMap[defaultErrorKey];
   }

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -27,7 +27,7 @@ function generateMessageFromStringArray(array: string[], key?: string): string {
 function generateFieldErrorFromErrorDetail(
   fieldName: string,
   errorDetail: ExceptionDetail
-) {
+): string[] | undefined {
   if (typeof fieldName !== "string") {
     throw new Error("fieldName can be string only");
   }
@@ -96,13 +96,22 @@ function getStringMessage(
       } else {
         const defaultErrorKey = errorDetailKeys[0];
 
-        // Generate message from the immediately found field error
-        message = getStringMessage(errorDetailValue[defaultErrorKey], {
-          customKey: getErrorKeyForStringMessageGenerator(
-            defaultErrorKey,
+        // If error detail is array of objects, it is a nested error, so
+        // generation should continue with the original key options
+        if (isArrayOfObjects(errorDetailValue[defaultErrorKey])) {
+          message = getStringMessage(
+            errorDetailValue[defaultErrorKey],
             keyOptions
-          )
-        });
+          );
+        } else {
+          message = getStringMessage(errorDetailValue[defaultErrorKey], {
+            // If not an array of objects, generate final error key using options
+            customKey: getErrorKeyForStringMessageGenerator(
+              defaultErrorKey,
+              keyOptions
+            )
+          });
+        }
       }
     }
   } else {

--- a/tests/utils/errorUtils.test.ts
+++ b/tests/utils/errorUtils.test.ts
@@ -302,6 +302,39 @@ describe("getStringMessage", () => {
       expect(message).toBe(`${key}: ${mockErrorDetail[0]}`);
     });
   });
+
+  describe("when error detail is an object of an array of objects", () => {
+    const mockErrorDetail: ExceptionDetailValue = {
+      manual_part_process_quotes: [
+        {lead_time: ["Lead time is required."]},
+        {lead_time: ["Lead time is required."]}
+      ]
+    };
+
+    it("should return the first meaningful error", () => {
+      const message = getStringMessage(mockErrorDetail);
+
+      expect(message).toBe("lead_time: Lead time is required.");
+    });
+
+    it("should remove error key when `shouldHideErrorKey` is true", () => {
+      const message = getStringMessage(mockErrorDetail, {
+        shouldHideErrorKey: true
+      });
+
+      expect(message).toBe("Lead time is required.");
+    });
+
+    it("should replace error key using given `fieldLabelMap`", () => {
+      const message = getStringMessage(mockErrorDetail, {
+        fieldLabelMap: {
+          lead_time: "TIME"
+        }
+      });
+
+      expect(message).toBe("TIME: Lead time is required.");
+    });
+  });
 });
 
 describe("deleteProperty", () => {


### PR DESCRIPTION
* Make sure error message generation options are applied to errors with nested detail objects (error detail is an object of an array of objects)
* Removes redundant `isArray` check inside `getStringMessage` (`isArrayOfStrings` and `isArrayOfObjects` functions check if input is an array internally)

Closes #19